### PR TITLE
Fix api url

### DIFF
--- a/ADFSimple/pipeline/Process_Model.json
+++ b/ADFSimple/pipeline/Process_Model.json
@@ -193,7 +193,7 @@
 			},
 			"Server": {
 				"type": "String",
-				"defaultValue": "asazure://northeurope.asazure.windows.net/meetup"
+				"defaultValue": "meetup"
 			},
 			"DatabaseName": {
 				"type": "String",

--- a/ADFSimple/pipeline/Process_Model.json
+++ b/ADFSimple/pipeline/Process_Model.json
@@ -50,7 +50,7 @@
 				"userProperties": [],
 				"typeProperties": {
 					"url": {
-						"value": "@concat(replace(pipeline().parameters.Server,'asazure://','https://')\n,'/models/',pipeline().parameters.DatabaseName\n,'/refreshes')",
+						"value": "@concat('https://'\n,pipeline().parameters.Region\n,'.asazure.windows.net/servers/'\n,pipeline().parameters.Server\n,'/models/'\n,pipeline().parameters.DatabaseName\n,'/refreshes')",
 						"type": "Expression"
 					},
 					"method": "POST",
@@ -96,7 +96,7 @@
 							"userProperties": [],
 							"typeProperties": {
 								"url": {
-									"value": "@concat(replace(pipeline().parameters.Server,'asazure://','https://')\n,'/models/',pipeline().parameters.DatabaseName\n,'/refreshes')",
+									"value": "@concat('https://'\n,pipeline().parameters.Region\n,'.asazure.windows.net/servers/'\n,pipeline().parameters.Server\n,'/models/'\n,pipeline().parameters.DatabaseName\n,'/refreshes')",
 									"type": "Expression"
 								},
 								"method": "GET",


### PR DESCRIPTION
### Context
Replace on server name (asazure://westus.asazure.windows.net/myserver -> https://westus.asazure.windows.net/myserver) isn't equal to API base url (https://westus.asazure.windows.net/servers/myserver)

API documentation : https://docs.microsoft.com/en-us/azure/analysis-services/analysis-services-async-refresh#base-url

### Proposed fix
- API urls as : https://`pipeline().parameters.Region`.asazure.windows.net/servers/`pipeline().parameters.Server`/...
- _Server_ parameter as `myserver` instead of `asazure://westus.asazure.windows.net/myserver`